### PR TITLE
Add a `leading` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,3 +189,34 @@ function InputWhichFetchesSomeData({ defaultValue, asyncFetchData }) {
   return <input defaultValue={defaultValue} onChange={(e) => debouncedFunction(e.target.value)} />;
 }
 ```
+
+#### leading calls
+
+Both `useDebounce` and `useDebouncedCallback` work with the `leading` option. This param will execute the function once immediately when called. Subsequent calls will be debounced until the timeout expires. 
+
+For more information on how leading debounce calls work see: https://lodash.com/docs/#debounce
+
+```javascript
+import React, { useState } from 'react';
+import { useDebounce } from 'use-debounce';
+
+export default function Input() {
+  const [text, setText] = useState('Hello');
+  const [value] = useDebounce(text, 1000, { leading: true });
+  
+  // value is updated immediately when text changes the first time, 
+  // but all subsequent changes are debounced.
+  return (
+    <div>
+      <input
+        defaultValue={'Hello'}
+        onChange={(e) => {
+          setText(e.target.value);
+        }}
+      />
+      <p>Actual value: {text}</p>
+      <p>Debounce value: {value}</p>
+    </div>
+  );
+}
+```

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -1,7 +1,7 @@
 import { useState, useCallback, useRef, useEffect } from 'react';
 import useDebouncedCallback from './callback';
 
-export default function useDebounce<T>(value: T, delay: number, options?: { maxWait?: number }): [T, () => void] {
+export default function useDebounce<T>(value: T, delay: number, options?: { maxWait?: number, leading?: boolean }): [T, () => void] {
   const [state, dispatch] = useState(value);
   const [callback, cancel] = useDebouncedCallback(useCallback((value) => dispatch(value), []), delay, options);
   const previousValue = useRef(value);

--- a/test/cache.test.tsx
+++ b/test/cache.test.tsx
@@ -38,6 +38,37 @@ describe('useDebounce', () => {
     expect(tree.text()).toBe('Hello world');
   });
 
+  it('will update value immediately if leading is set to true', () => {
+    function Component({ text }) {
+      const [value] = useDebounce(text, 1000, {leading: true});
+      return <div>{value}</div>;
+    }
+    const tree = Enzyme.mount(<Component text={'Hello'} />);
+
+    // check inited value
+    expect(tree.text()).toBe('Hello');
+
+    act(() => {
+      tree.setProps({ text: 'Hello world' });
+    });
+
+    // value should be set immediately by first leading call
+    expect(tree.text()).toBe('Hello world');
+
+    act(() => {
+      tree.setProps({ text: 'Hello again, world' });
+    });
+
+    // timeout shouldn't have been called yet after leading call was executed
+    expect(tree.text()).toBe('Hello world');
+
+    act(() => {
+      jest.runAllTimers();
+    });
+    // final value should update as per last timeout
+    expect(tree.text()).toBe('Hello again, world');
+  });
+
   it('will cancel value when cancel method is called', () => {
     function Component({ text }) {
       const [value, cancelValue] = useDebounce(text, 1000);

--- a/test/callback.test.tsx
+++ b/test/callback.test.tsx
@@ -26,6 +26,68 @@ describe('useDebouncedCallback', () => {
     expect(callback.mock.calls.length).toBe(1);
   });
 
+  it('will call leading callback immediately (but only once)', () => {
+    const callback = jest.fn();
+
+    function Component() {
+      const [debouncedCallback] = useDebouncedCallback(callback, 1000, {leading: true});
+      debouncedCallback();
+      return null;
+    }
+    Enzyme.mount(<Component />);
+
+    expect(callback.mock.calls.length).toBe(1);
+
+    act(() => {
+      jest.runAllTimers();
+    });
+
+    expect(callback.mock.calls.length).toBe(1);
+  });
+
+  it('will call leading callback as well as next debounced call', () => {
+    const callback = jest.fn();
+
+    function Component() {
+      const [debouncedCallback] = useDebouncedCallback(callback, 1000, {leading: true});
+      debouncedCallback();
+      debouncedCallback();
+      return null;
+    }
+    Enzyme.mount(<Component />);
+
+    expect(callback.mock.calls.length).toBe(1);
+
+    act(() => {
+      jest.runAllTimers();
+    });
+
+    expect(callback.mock.calls.length).toBe(2);
+  });
+  
+  it('will call a second leading callback if no debounced callbacks are pending', () => {
+    const callback = jest.fn();
+
+    function Component() {
+      const [debouncedCallback] = useDebouncedCallback(callback, 1000, {leading: true});
+      debouncedCallback();
+      debouncedCallback();
+      setTimeout(() => {
+        debouncedCallback();
+      }, 1001);
+      return null;
+    }
+    Enzyme.mount(<Component />);
+
+    expect(callback.mock.calls.length).toBe(1);
+
+    act(() => {
+      jest.runTimersToTime(1001);
+    });
+
+    expect(callback.mock.calls.length).toBe(3);
+  });
+
   it('will call callback only with the latest params', () => {
     const callback = jest.fn((param) => {
       expect(param).toBe('Right param');


### PR DESCRIPTION
Allow values and callbacks to be invoked immediately through a new `leading` option. This behaves similarly to the Lodash implementation: https://lodash.com/docs/#debounce

Great library by the way! Super useful for the project I'm currently working on 😃 
