### PR TITLE
Emit code in ESM format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 examples/bundle.js
 node_modules
 npm-debug.js
+esm
 lib
 .git
 .DS_store

--- a/package.json
+++ b/package.json
@@ -3,10 +3,14 @@
   "version": "2.2.1",
   "description": "Debounce hook for react",
   "main": "lib/index.js",
+  "module": "esm/index.js",
   "types": "./lib",
+  "sideEffects": false,
   "scripts": {
     "test": "yarn jest",
-    "build": "yarn test && eslint \"src/**.ts\" && tsc -p ./",
+    "build": "yarn test && eslint \"src/**.ts\" && yarn build:cjs && yarn build:es",
+    "build:cjs": "tsc",
+    "build:es": "tsc -m esNext --outDir esm",
     "size": "size-limit"
   },
   "size-limit": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "module": "commonjs",
+    "moduleResolution": "node",
     "target": "es5",
     "outDir": "./lib",
     "lib": ["es5", "es2015", "dom"],


### PR DESCRIPTION
Right now, the library is not tree shakeable. These changes will enable tree shaking.