### PR TITLE
Include only necessary file in the npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,8 +1,0 @@
-.idea
-.vscode
-node_modules
-npm-debug.js
-.git
-.DS_store
-coverage
-tmp

--- a/package.json
+++ b/package.json
@@ -32,6 +32,10 @@
   "bugs": {
     "url": "https://github.com/xnimorz/use-debounce/issues"
   },
+  "files": [
+    "esm",
+    "lib"
+  ],
   "peerDependencies": {
     "react": ">=16.8.0"
   },


### PR DESCRIPTION
It makes sense to include only the necessary minimum set of files in the package to reduce the package size:
1. `esm`
2. `lib`
3. `CHANGELOG.md`
4. `LICENSE`
5. `package.json`
6. `README.md`

For comparison:
![Снимок экрана 2019-09-25 в 23 09 44](https://user-images.githubusercontent.com/153412/65635756-9d3e7180-dfe9-11e9-9a0e-2a86c7cc6331.png)

Also I use the `files` package.json property instead of `.npmignore` иecause I think it's a better approach. Motivation: https://medium.com/@jdxcode/for-the-love-of-god-dont-use-npmignore-f93c08909d8d.