### PR TITLE
Allow custom equality function in useDebounce

### DIFF
--- a/src/useDebounce.ts
+++ b/src/useDebounce.ts
@@ -1,7 +1,7 @@
 import { useState, useCallback, useRef, useEffect } from 'react';
 import useDebouncedCallback from './useDebouncedCallback';
 
-function refEquality<T>(left: T, right: T): boolean {
+function valueEquality<T>(left: T, right: T): boolean {
   return left === right;
 }
 
@@ -9,7 +9,7 @@ export default function useDebounce<T>(
   value: T,
   delay: number,
   options?: { maxWait?: number; leading?: boolean },
-  equalityFn: (left: T, right: T) => boolean = refEquality
+  equalityFn: (left: T, right: T) => boolean = valueEquality
 ): [T, () => void] {
   const [state, dispatch] = useState(value);
   const [callback, cancel] = useDebouncedCallback(useCallback((value) => dispatch(value), []), delay, options);

--- a/src/useDebounce.ts
+++ b/src/useDebounce.ts
@@ -1,10 +1,15 @@
 import { useState, useCallback, useRef, useEffect } from 'react';
 import useDebouncedCallback from './useDebouncedCallback';
 
+function refEquality<T>(left: T, right: T): boolean {
+  return left === right;
+}
+
 export default function useDebounce<T>(
   value: T,
   delay: number,
-  options?: { maxWait?: number; leading?: boolean }
+  options?: { maxWait?: number; leading?: boolean },
+  equalityFn: (left: T, right: T) => boolean = refEquality
 ): [T, () => void] {
   const [state, dispatch] = useState(value);
   const [callback, cancel] = useDebouncedCallback(useCallback((value) => dispatch(value), []), delay, options);
@@ -12,11 +17,11 @@ export default function useDebounce<T>(
 
   useEffect(() => {
     // We need to use this condition otherwise we will run debounce timer for the first render (including maxWait option)
-    if (previousValue.current !== value) {
+    if (!equalityFn(previousValue.current, value)) {
       callback(value);
       previousValue.current = value;
     }
-  }, [value, callback]);
+  }, [value, callback, equalityFn]);
 
   return [state, cancel];
 }

--- a/src/useDebounce.ts
+++ b/src/useDebounce.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback, useRef, useEffect } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import useDebouncedCallback from './useDebouncedCallback';
 
 function valueEquality<T>(left: T, right: T): boolean {
@@ -8,20 +8,21 @@ function valueEquality<T>(left: T, right: T): boolean {
 export default function useDebounce<T>(
   value: T,
   delay: number,
-  options?: { maxWait?: number; leading?: boolean },
-  equalityFn: (left: T, right: T) => boolean = valueEquality
+  options?: { maxWait?: number; leading?: boolean; equalityFn?: (left: T, right: T) => boolean }
 ): [T, () => void] {
+  const eq = options && options.equalityFn ? options.equalityFn : valueEquality;
+
   const [state, dispatch] = useState(value);
   const [callback, cancel] = useDebouncedCallback(useCallback((value) => dispatch(value), []), delay, options);
   const previousValue = useRef(value);
 
   useEffect(() => {
     // We need to use this condition otherwise we will run debounce timer for the first render (including maxWait option)
-    if (!equalityFn(previousValue.current, value)) {
+    if (!eq(previousValue.current, value)) {
       callback(value);
       previousValue.current = value;
     }
-  }, [value, callback, equalityFn]);
+  }, [value, callback, eq]);
 
   return [state, cancel];
 }

--- a/test/useDebounce.test.tsx
+++ b/test/useDebounce.test.tsx
@@ -247,4 +247,29 @@ describe('useDebounce', () => {
     // If maxWait wasn't started at the first render of the component, we shouldn't receive the new value
     expect(tree.text()).toBe('2');
   });
+
+  it('should use equality function if supplied', () => {
+    // Use equality function that always returns true
+    const eq = jest.fn((left: string, right: string): boolean => {
+      return true;
+    });
+
+    function Component({ text }) {
+      const [value] = useDebounce(text, 1000, {}, eq);
+      return <div>{value}</div>;
+    }
+
+    const tree = Enzyme.mount(<Component text={'Hello'} />);
+
+    expect(eq).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      tree.setProps({ text: 'Test' });
+    });
+
+    expect(eq).toHaveBeenCalledTimes(2);
+    expect(eq).toHaveBeenCalledWith('Hello', 'Test');
+    // Since the equality function always returns true, expect the value to stay the same
+    expect(tree.text()).toBe('Hello');
+  });
 });

--- a/test/useDebounce.test.tsx
+++ b/test/useDebounce.test.tsx
@@ -255,7 +255,7 @@ describe('useDebounce', () => {
     });
 
     function Component({ text }) {
-      const [value] = useDebounce(text, 1000, {}, eq);
+      const [value] = useDebounce(text, 1000, { equalityFn: eq });
       return <div>{value}</div>;
     }
 


### PR DESCRIPTION
This PR adds an optional parameter to `useDebounce` that can be used to provide a custom equality function (e.g. an equality function for deep object comparison) to the hook. It defaults to a simple strict equality comparison.

Let me know what you think 😄 
