### PR TITLE
Fix typings (especially return type of useDebouncedCallback)

### DIFF
--- a/src/useDebounce.ts
+++ b/src/useDebounce.ts
@@ -14,7 +14,7 @@ export default function useDebounce<T>(
 
   const [state, dispatch] = useState(value);
   const [callback, cancel, callPending] = useDebouncedCallback(
-    useCallback((value) => dispatch(value), []),
+    useCallback((value: T) => dispatch(value), []),
     delay,
     options
   );

--- a/src/useDebouncedCallback.ts
+++ b/src/useDebouncedCallback.ts
@@ -7,14 +7,14 @@ export default function useDebouncedCallback<T extends any[]>(
 ): [(...args: T) => void, () => void, () => void] {
   const maxWait = options.maxWait;
   const maxWaitHandler = useRef(null);
-  const maxWaitArgs: { current: T | [] }  = useRef([]);
+  const maxWaitArgs = useRef<T | []>([]);
 
   const leading = options.leading;
   const trailing = options.trailing === undefined ? true : options.trailing;
   const leadingCall = useRef(false);
 
   const functionTimeoutHandler = useRef(null);
-  const isComponentUnmounted: { current: boolean } = useRef(false);
+  const isComponentUnmounted = useRef(false);
 
   const debouncedFunction = useRef(callback);
   debouncedFunction.current = callback;

--- a/src/useDebouncedCallback.ts
+++ b/src/useDebouncedCallback.ts
@@ -1,13 +1,13 @@
 import { useRef, useCallback, useEffect } from 'react';
 
-export default function useDebouncedCallback<T extends (...args: any[]) => any>(
-  callback: T,
+export default function useDebouncedCallback<T extends any[]>(
+  callback: (...args: T) => unknown,
   delay: number,
   options: { maxWait?: number; leading?: boolean; trailing?: boolean } = {}
-): [T, () => void, () => void] {
+): [(...args: T) => void, () => void, () => void] {
   const maxWait = options.maxWait;
   const maxWaitHandler = useRef(null);
-  const maxWaitArgs: { current: any[] } = useRef([]);
+  const maxWaitArgs: { current: T | [] }  = useRef([]);
 
   const leading = options.leading;
   const trailing = options.trailing === undefined ? true : options.trailing;
@@ -37,7 +37,7 @@ export default function useDebouncedCallback<T extends (...args: any[]) => any>(
   );
 
   const debouncedCallback = useCallback(
-    (...args) => {
+    (...args: T) => {
       maxWaitArgs.current = args;
       clearTimeout(functionTimeoutHandler.current);
       if (leadingCall.current) {
@@ -85,5 +85,5 @@ export default function useDebouncedCallback<T extends (...args: any[]) => any>(
   }, [cancelDebouncedCallback]);
 
   // At the moment, we use 3 args array so that we save backward compatibility
-  return [debouncedCallback as T, cancelDebouncedCallback, callPending];
+  return [debouncedCallback, cancelDebouncedCallback, callPending];
 }

--- a/src/useDebouncedCallback.ts
+++ b/src/useDebouncedCallback.ts
@@ -1,6 +1,6 @@
 import { useRef, useCallback, useEffect } from 'react';
 
-export default function useDebouncedCallback<T extends any[]>(
+export default function useDebouncedCallback<T extends unknown[]>(
   callback: (...args: T) => unknown,
   delay: number,
   options: { maxWait?: number; leading?: boolean; trailing?: boolean } = {}


### PR DESCRIPTION
Hi, thank you for nice library.

I found return type of `useDebouncedCallback` is wrong.
Given `(T) => P` as callback, `debouncedCallback` never returns `P` (or anything), so signature of `debouncedCallback ` should be `(T) => void`, but currently its signature is `(T) => P`. With this p-r, `debouncedCallback` will have `(T) => void` signature, matching with actual behavior.
(And additionally I removed explicit type annotations for `useRef` since it's not necessary. )

Note:
- This p-r changes only type annotations, therefore the compiled JS will not change
- This p-r may cause type check errors in users' codes since type signature changes
  - But I should change it anyway, because current signature is wrong
