### PR TITLE
chore(build): del old cache

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "sideEffects": false,
   "scripts": {
     "test": "yarn jest",
-    "build": "yarn test && eslint \"src/**.ts\" && yarn build:cjs && yarn build:es",
+    "build": "yarn test && eslint \"src/**.ts\" && rm -rf ./lib/* ./esm/* && yarn build:cjs && yarn build:es",
     "build:cjs": "tsc",
     "build:es": "tsc -m esNext --outDir esm",
     "size": "size-limit"


### PR DESCRIPTION
Hi~

When I actually used it, I found other old files in the npm package.
Of course, this does not affect the actual use.
But I feel it can be avoided automatically. Of course, you can delete it manually. :)

Thanks~ 🙋‍♂️

<img width="259" alt="截屏2020-04-23 23 17 56" src="https://user-images.githubusercontent.com/28584349/80118646-4a4a8e00-85bb-11ea-98da-c45f344562e2.png">
