### PR TITLE
Optimization: extra callback

### DIFF
--- a/src/useDebouncedCallback.ts
+++ b/src/useDebouncedCallback.ts
@@ -64,16 +64,6 @@ export default function useDebouncedCallback<T extends (...args: any[]) => Retur
     [useRAF]
   );
 
-  const cancelTimer = useCallback(
-    (id) => {
-      if (useRAF) {
-        return cancelAnimationFrame(id);
-      }
-      clearTimeout(id);
-    },
-    [useRAF]
-  );
-
   const remainingWait = useCallback(
     (time) => {
       const timeSinceLastCall = time - lastCallTime.current;
@@ -143,11 +133,11 @@ export default function useDebouncedCallback<T extends (...args: any[]) => Retur
 
   const cancel = useCallback(() => {
     if (timerId.current !== undefined) {
-      cancelTimer(timerId.current);
+      useRAF ? cancelAnimationFrame(timerId.current) : clearTimeout(timerId.current);
     }
     lastInvokeTime.current = 0;
     lastArgs.current = lastCallTime.current = lastThis.current = timerId.current = undefined;
-  }, [cancelTimer]);
+  }, [useRAF]);
 
   const flush = useCallback(() => {
     return timerId.current === undefined ? result.current : trailingEdge(Date.now());


### PR DESCRIPTION
Round 2.

`cancel` is the only function that calls `cancelCallback`, so it doesn't make a lot of sense to have two callbacks instead of one. I just merged them. 

–12 bytes:

```diff
-  Size:       896 B with all dependencies, minified and gzipped
+  Size:       884 B with all dependencies, minified and gzipped

-  Size:       857 B with all dependencies, minified and gzipped
+  Size:       846 B with all dependencies, minified and gzipped

-  Size:       740 B with all dependencies, minified and gzipped
+  Size:       728 B with all dependencies, minified and gzipped
```