### PR TITLE
Optimization: timerId conditions

### DIFF
--- a/src/useDebouncedCallback.ts
+++ b/src/useDebouncedCallback.ts
@@ -132,7 +132,7 @@ export default function useDebouncedCallback<T extends (...args: any[]) => Retur
   );
 
   const cancel = useCallback(() => {
-    if (timerId.current !== undefined) {
+    if (timerId.current) {
       useRAF ? cancelAnimationFrame(timerId.current) : clearTimeout(timerId.current);
     }
     lastInvokeTime.current = 0;
@@ -140,7 +140,7 @@ export default function useDebouncedCallback<T extends (...args: any[]) => Retur
   }, [useRAF]);
 
   const flush = useCallback(() => {
-    return timerId.current === undefined ? result.current : trailingEdge(Date.now());
+    return !timerId.current ? result.current : trailingEdge(Date.now());
   }, [trailingEdge]);
 
   useEffect(() => {
@@ -160,7 +160,7 @@ export default function useDebouncedCallback<T extends (...args: any[]) => Retur
       lastCallTime.current = time;
 
       if (isInvoking) {
-        if (timerId.current === undefined && mounted.current) {
+        if (!timerId.current && mounted.current) {
           return leadingEdge(lastCallTime.current);
         }
         if (maxing) {
@@ -169,7 +169,7 @@ export default function useDebouncedCallback<T extends (...args: any[]) => Retur
           return invokeFunc(lastCallTime.current);
         }
       }
-      if (timerId.current === undefined) {
+      if (!timerId.current) {
         timerId.current = startTimer(timerExpired, wait);
       }
       return result.current;
@@ -178,7 +178,7 @@ export default function useDebouncedCallback<T extends (...args: any[]) => Retur
   );
 
   const pending = useCallback(() => {
-    return timerId.current !== undefined;
+    return !!timerId.current;
   }, []);
 
   const debouncedState: DebouncedState<T> = useMemo(


### PR DESCRIPTION
Round 3 (~ –13 bytes)

Replacing strict `timerId` conditions with short truthy/falsy ones:
```js
timerId === undefined → !timerId
timerId !== undefined → timerId
```

Why? Because `setTimeout` and `requestAnimationFrame` don't return zero (or returns an object in NodeJS), so any `timerId` you have is passing the truthy conditions.

https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/setTimeout

> The returned timeoutID is **a positive integer value**

https://developer.mozilla.org/en-US/docs/Web/API/window/requestAnimationFrame

> A long integer value, the request id, that uniquely identifies the entry in the callback list. **This is a non-zero value**...

```diff
-  Size:       896 B with all dependencies, minified and gzipped
+  Size:       882 B with all dependencies, minified and gzipped

-  Size:       857 B with all dependencies, minified and gzipped
+  Size:       846 B with all dependencies, minified and gzipped

-  Size:       740 B with all dependencies, minified and gzipped
+  Size:       727 B with all dependencies, minified and gzipped
```