### PR TITLE
Optimization: Move `remainingWait` to `timerExpired`

### DIFF
--- a/src/useDebouncedCallback.ts
+++ b/src/useDebouncedCallback.ts
@@ -105,6 +105,7 @@ export default function useDebouncedCallback<T extends (...args: any[]) => Retur
       return trailingEdge(time);
     }
 
+    // Remaining wait calculation
     const timeSinceLastCall = time - lastCallTime.current;
     const timeSinceLastInvoke = time - lastInvokeTime.current;
     const timeWaiting = wait - timeSinceLastCall;


### PR DESCRIPTION
Round 6: **(~ –11 bytes)**

Merge two callbacks into one in order to reduce the number of useCallback+deps declarations.

```diff
-  Size:       853 B with all dependencies, minified and gzipped
+  Size:       844 B with all dependencies, minified and gzipped

-  Size:       817 B with all dependencies, minified and gzipped
+  Size:       808 B with all dependencies, minified and gzipped

-  Size:       700 B with all dependencies, minified and gzipped
+  Size:       693 B with all dependencies, minified and gzipped
```