### PR TITLE
Optimization: shorten `useDebouncedCallback` code a bit

### DIFF
--- a/src/useDebouncedCallback.ts
+++ b/src/useDebouncedCallback.ts
@@ -37,7 +37,10 @@ export default function useDebouncedCallback<T extends (...args: any[]) => Retur
   if (typeof func !== 'function') {
     throw new TypeError('Expected a function');
   }
+
   wait = +wait || 0;
+  options = options || {};
+
   const leading = !!options.leading;
   const trailing = 'trailing' in options ? !!options.trailing : true; // `true` by default
   const maxing = 'maxWait' in options;

--- a/src/useDebouncedCallback.ts
+++ b/src/useDebouncedCallback.ts
@@ -49,8 +49,7 @@ export default function useDebouncedCallback<T extends (...args: any[]) => Retur
 
     lastArgs.current = lastThis.current = null;
     lastInvokeTime.current = time;
-    result.current = funcRef.current.apply(thisArg, args);
-    return result.current;
+    return (result.current = funcRef.current.apply(thisArg, args));
   }, []);
 
   const startTimer = useCallback(

--- a/src/useDebouncedCallback.ts
+++ b/src/useDebouncedCallback.ts
@@ -19,7 +19,7 @@ export interface DebouncedState<T extends (...args: any[]) => ReturnType<T>> ext
 export default function useDebouncedCallback<T extends (...args: any[]) => ReturnType<T>>(
   func: T,
   wait: number,
-  options: Options = { leading: false, trailing: true }
+  options?: Options
 ): DebouncedState<T> {
   const lastCallTime = useRef(null);
   const lastInvokeTime = useRef(0);
@@ -39,7 +39,7 @@ export default function useDebouncedCallback<T extends (...args: any[]) => Retur
   }
   wait = +wait || 0;
   const leading = !!options.leading;
-  const trailing = 'trailing' in options ? !!options.trailing : true;
+  const trailing = 'trailing' in options ? !!options.trailing : true; // `true` by default
   const maxing = 'maxWait' in options;
   const maxWait = maxing ? Math.max(+options.maxWait || 0, wait) : null;
 

--- a/src/useDebouncedCallback.ts
+++ b/src/useDebouncedCallback.ts
@@ -55,11 +55,8 @@ export default function useDebouncedCallback<T extends (...args: any[]) => Retur
 
   const startTimer = useCallback(
     (pendingFunc, wait) => {
-      if (useRAF) {
-        cancelAnimationFrame(timerId.current);
-        return requestAnimationFrame(pendingFunc);
-      }
-      return setTimeout(pendingFunc, wait);
+      if (useRAF) cancelAnimationFrame(timerId.current);
+      timerId.current = useRAF ? requestAnimationFrame(pendingFunc) : setTimeout(pendingFunc, wait);
     },
     [useRAF]
   );
@@ -112,7 +109,7 @@ export default function useDebouncedCallback<T extends (...args: any[]) => Retur
     const remainingWait = maxing ? Math.min(timeWaiting, maxWait - timeSinceLastInvoke) : timeWaiting;
 
     // Restart the timer
-    timerId.current = startTimer(timerExpired, remainingWait);
+    startTimer(timerExpired, remainingWait);
   }, [maxWait, maxing, shouldInvoke, startTimer, trailingEdge, wait]);
 
   const cancel = useCallback(() => {
@@ -148,18 +145,18 @@ export default function useDebouncedCallback<T extends (...args: any[]) => Retur
           // Reset any `maxWait` timer.
           lastInvokeTime.current = lastCallTime.current;
           // Start the timer for the trailing edge.
-          timerId.current = startTimer(timerExpired, wait);
+          startTimer(timerExpired, wait);
           // Invoke the leading edge.
           return leading ? invokeFunc(lastCallTime.current) : result.current;
         }
         if (maxing) {
           // Handle invocations in a tight loop.
-          timerId.current = startTimer(timerExpired, wait);
+          startTimer(timerExpired, wait);
           return invokeFunc(lastCallTime.current);
         }
       }
       if (!timerId.current) {
-        timerId.current = startTimer(timerExpired, wait);
+        startTimer(timerExpired, wait);
       }
       return result.current;
     },


### PR DESCRIPTION
Round 7: **(~ –18 bytes)**

1. We don't need default `options` value because you check and set the default values for `leading` and `trailing` anyway (see lines 41-42).
2. Moved `timerId.current = ` assingment inside of `startTimer` to reduce code duplication
3. Combined return and assignment statements into one line.
 
```diff
-  Size:       844 B with all dependencies, minified and gzipped
+  Size:       826 B with all dependencies, minified and gzipped

-  Size:       808 B with all dependencies, minified and gzipped
+  Size:       790 B with all dependencies, minified and gzipped

-  Size:       693 B with all dependencies, minified and gzipped
+  Size:       675 B with all dependencies, minified and gzipped
```