### PR TITLE
Fix v5 upgrade instructions for useDebounce case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,7 +87,7 @@
   New:
 
   ```js
-  const [value, fn] = useDebouncedCallback(/*...*/);
+  const [value, fn] = useDebounce(/*...*/);
   /**
    * value is just a value without changes
    * But fn now is an object: {


### PR DESCRIPTION
Update v5 upgrade text in changelog. 
It was using `useDebouncedCallback` instead of `useDebounce` when showing how `useDebounce` return value has changed between versions