### PR TITLE
export types from package

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,13 @@
 import useDebounce from './useDebounce';
-import useDebouncedCallback from './useDebouncedCallback';
+import useDebouncedCallback, { CallOptions, ControlFunctions, DebouncedState, Options } from './useDebouncedCallback';
 import useThrottledCallback from './useThrottledCallback';
 
-export { useDebounce, useDebouncedCallback, useThrottledCallback };
+export {
+  useDebounce,
+  useDebouncedCallback,
+  useThrottledCallback,
+  CallOptions,
+  ControlFunctions,
+  DebouncedState,
+  Options,
+};


### PR DESCRIPTION
This is useful for example when declaring a custom hook that returns a denounced function and the code-base enforces explicitly declared return types.

```tsx
import type { DebouncedState } from 'use-debounced';

type Result = DebouncedState<React.ChangeEventHandler<HTMLInputElement>>;

export const useProgressBarStepping = (): Result => {
  const onChange = useDebouncedCallback(
    (event: React.ChangeEvent<HTMLInputElement>): void => {
      // ...
    },
    100,
    { maxWait: 200 },
  );

  return onChange;
};
```

Especially since it's impossible to extract `DebouncedState` via Typescript version lower than v4.7. See
https://stackoverflow.com/questions/50321419/typescript-returntype-of-generic-function