### PR TITLE
Update package.json to support typescript node16

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,11 +10,13 @@
   "exports": {
     ".": {
       "node": {
+        "types": "./dist/index.d.ts",
         "module": "./dist/index.module.js",
         "require": "./dist/index.js",
         "import": "./dist/index.mjs"
       },
       "browser": {
+        "types": "./dist/index.d.ts",
         "import": "./dist/index.module.js",
         "require": "./dist/index.js"
       },


### PR DESCRIPTION
To find the types for a package,  typescript uses a rule where it finds the ".js" file
for the import and then changes the extension to ".d.ts".

For typescript versions 4.6 and below and typescript 4.7 with moduleResolution "node",
typescript is looking at the "require" entry in "exports" and therefore finds "./dist/index.js"
and then looks for "./dist/index.d.ts" to find the types.  This file exists so everything works.

For typescript 4.7 with node16 module resolution, typescript is now looking at the "module"
field and finding "./dist/index.module.js".  Typescript then searches for a file "./dist/index.module.d.ts"
to find types, but that file does not exist and typescript produces an error

error TS7016: Could not find a declaration file for module 'use-debounce'.

The fix is just to explicitly specify the path to the types file.   This fixes typescript 4.7+
with moduleResolution "node16"

See https://github.com/microsoft/TypeScript/issues/49160 and 
https://www.typescriptlang.org/docs/handbook/esm-node.html#packagejson-exports-imports-and-self-referencing