### PR TITLE
Simplify extended useDebouncedCallback function types

### DIFF
--- a/src/useDebouncedCallback.ts
+++ b/src/useDebouncedCallback.ts
@@ -107,7 +107,7 @@ export interface DebouncedState<T extends (...args: any[]) => ReturnType<T>> ext
  * // Check for pending invocations.
  * const status = debounced.pending() ? "Pending..." : "Ready"
  */
-export default function useDebouncedCallback<T extends (...args: any[]) => ReturnType<T>>(
+export default function useDebouncedCallback<T extends (...args: any) => ReturnType<T>>(
   func: T,
   wait?: number,
   options?: Options


### PR DESCRIPTION
The types are failing if the function is used with other generic functions.
For example type `<Args extends Array<unknown>` fails this check.

A minimal example of the failing types that this change would fix:
```ts
import type { ActionCreatorWithPreparedPayload } from "@reduxjs/toolkit";
import { useDispatch } from "react-redux";
import { useDebouncedCallback } from "use-debounce";

interface UseFilterUpdaterParams<Args extends Array<unknown>, Payload> {
  updateFunction: ActionCreatorWithPreparedPayload<Args, Payload>;
  DEBOUNCED_HANDLER_MS?: number;
}

const useUpdater = <Args extends Array<unknown>, Payload>({
  updateFunction,
  DEBOUNCED_HANDLER_MS = 0,
}: UseFilterUpdaterParams<Args, Payload>) => {
  const dispatch = useDispatch();

  /**
   * Argument of type '(...props: Args) => void' is not assignable to parameter of type '(...args: any[]) => void'.
   *   Types of parameters 'props' and 'args' are incompatible.
   *     Type 'any[]' is not assignable to type 'Args'.
   *       'any[]' is assignable to the constraint of type 'Args', but 'Args' could be instantiated with a different subtype of constraint 'unknown[]'.(2345)
   */
  const debouncedCallback = useDebouncedCallback((...props: Args) => {
    dispatch(updateFunction(...props));
  }, DEBOUNCED_HANDLER_MS);

  return debouncedCallback;
};

export default useUpdater;
```

Reproducible example: [Typescript playground](https://www.typescriptlang.org/play?#code/JYWwDg9gTgLgBDAnmApnA3nAggYxsCAOwGEoUBDGaAdWBgAsAFMscsgE0fMQBsJz2cAL5wAZlAgg4AIgACHAK4APAFYBnAPRUIPANZ1pAbgBQoSLAxwFalABFga1jBz1hYiVOllyeALSKlI1NwaHhMazsUACMIBUIcFHZich4eKJ9dN3FJGQjfdmjY+JQg00IYFChRHzQAVRsAMWAeCqhasHZKSq4ochA1AB4sKABzNTgUJQrCdnHh3sQBuN1CCAB3QgA+ABo4Ll5+dk2MYzgrDq6GuLwCQgAubBuiUgoqKFoGZhRWDn2+ASGozUuz+h02JjOtgAogAhADytQAcsQobYAPoACSwiNsABkoQAlNEAWQAygB+B6EBQgKKVExCYzGHBENTwCLtTqtOAAXjggLGEymKBmcygCyWhBW6y2IO4-yOAAp0KdzlyUFd4vgiNtVdD4UiUeisTj8USyby4AAGXVCB71DXNVqcrpQHp9QbDMZyg4CTYASl5xxVZxZhDZcHYDicLktEXsjkoLkV-pMqrDEYKMWuiWSqXSOEyfPjhRzSRSaQyisVADo62AJGA1A8vWpAzzg6qzlHE856IqFBcKpqnoRa-XG23U6qhLt9QjkajMdi8YSSaTp6qyDAFFBCJHS8Vy-mMgy05NzPACtUFC0rDYXa0TEA)