### PR TITLE
Represent correct return type from useDebounce()

### DIFF
--- a/src/useDebounce.ts
+++ b/src/useDebounce.ts
@@ -1,5 +1,5 @@
 import { useCallback, useRef, useState, Dispatch } from 'react';
-import useDebouncedCallback, { ControlFunctions } from './useDebouncedCallback';
+import useDebouncedCallback, { DebouncedState } from './useDebouncedCallback';
 
 function valueEquality<T>(left: T, right: T): boolean {
   return left === right;
@@ -19,7 +19,7 @@ export default function useDebounce<T>(
   value: T,
   delay: number,
   options?: { maxWait?: number; leading?: boolean; trailing?: boolean; equalityFn?: (left: T, right: T) => boolean }
-): [T, ControlFunctions] {
+): [T, DebouncedState<(value: T) => void>] {
   const eq = (options && options.equalityFn) || valueEquality;
 
   const [state, dispatch] = useStateIgnoreCallback(value);

--- a/test/useDebounce.test.tsx
+++ b/test/useDebounce.test.tsx
@@ -301,13 +301,13 @@ describe('useDebounce', () => {
   });
 
   it('should preserve debounced object between re-renders', () => {
-    let cachedDebounced = null;
+    let cachedDebounced: unknown = null;
     function Component({ text }) {
       const [value, debounced] = useDebounce(text, 1000);
       if (cachedDebounced == null) {
         cachedDebounced = debounced;
       } else {
-        expect(cachedDebounced).toBe(debounced)
+        expect(cachedDebounced).toBe(debounced);
       }
       return <div>{value}</div>;
     }
@@ -327,8 +327,7 @@ describe('useDebounce', () => {
     });
     // after runAllTimer text should be updated
     expect(tree.text()).toBe('Hello world');
-  })
-  
+  });
 
   it('should change debounced.isPending to true as soon as the function is called in a sync way', () => {
     function Component({ text }) {
@@ -356,5 +355,5 @@ describe('useDebounce', () => {
     });
     // after runAllTimer text should be updated
     expect(tree.text()).toBe('Hello world');
-  })
+  });
 });


### PR DESCRIPTION
The return type now correctly reflects that the second item can be called manually as a debounced setter, which is super useful in certain situations.