### PR TITLE
refactor(type): function parameters type

### DIFF
--- a/src/useDebouncedCallback.ts
+++ b/src/useDebouncedCallback.ts
@@ -37,7 +37,7 @@ export interface ControlFunctions {
  * Subsequent calls to the debounced function `debounced.callback` return the result of the last func invocation.
  * Note, that if there are no previous invocations it's mean you will get undefined. You should check it in your code properly.
  */
-export interface DebouncedState<T extends (...args: any[]) => ReturnType<T>> extends ControlFunctions {
+export interface DebouncedState<T extends (...args: any) => ReturnType<T>> extends ControlFunctions {
   (...args: Parameters<T>): ReturnType<T> | undefined;
 }
 

--- a/src/useThrottledCallback.ts
+++ b/src/useThrottledCallback.ts
@@ -52,7 +52,7 @@ import useDebouncedCallback, { CallOptions, DebouncedState } from './useDebounce
  * // Cancel the trailing throttled invocation.
  * window.addEventListener('popstate', throttled.cancel);
  */
-export default function useThrottledCallback<T extends (...args: any[]) => ReturnType<T>>(
+export default function useThrottledCallback<T extends (...args: any) => ReturnType<T>>(
   func: T,
   wait: number,
   { leading = true, trailing = true }: CallOptions = {}


### PR DESCRIPTION
Hi, I'm having some problems customizing types.

```
Type '(...args: Parameters<T>) => Promise<void>' does not satisfy the constraint '(...args: any[]) => Promise<void>'
```

<img width="1089" alt="image" src="https://user-images.githubusercontent.com/28584349/220041476-d0917aa0-76d1-4613-8363-bd7d7ed3008c.png">

like

```ts
export type ReturnResultType<T extends (...args: any) => ReturnType<T>> = {
  callback: DebouncedState<(...args: Parameters<T>) => Promise<void>>;
};
```

So I want to lift the restriction on the array type of function parameters, same as `Parameters`

```ts
/**
 * Obtain the parameters of a function type in a tuple
 */
type Parameters<T extends (...args: any) => any> = T extends (...args: infer P) => any ? P : never;
```
