### PR TITLE
Tweak `package.json#exports` manifest

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,18 +9,10 @@
   "umd:main": "dist/index.umd.js",
   "exports": {
     ".": {
-      "node": {
-        "types": "./dist/index.d.ts",
-        "module": "./dist/index.module.js",
-        "require": "./dist/index.js",
-        "import": "./dist/index.mjs"
-      },
-      "browser": {
-        "types": "./dist/index.d.ts",
-        "import": "./dist/index.module.js",
-        "require": "./dist/index.js"
-      },
-      "default": "./dist/index.module.js"
+      "types": "./dist/index.d.ts",
+      "module": "./dist/index.module.js",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
     },
     "./package.json": "./package.json"
   },


### PR DESCRIPTION
My main motivation behind this PR was to fix `types`. When using this package without `node` and `browser` conditions the types couldn't be found.

I've reexamined the structure of the declared `exports` and I concluded that they are a little bit over-engineered since, as far as I can tell, you are actually not shipping any env-specific code. So it should be possible to simplify this to only those basic~ conditions