### PR TITLE
Remove incorrect docblock about obsolete .callback property

### DIFF
--- a/src/useDebouncedCallback.ts
+++ b/src/useDebouncedCallback.ts
@@ -38,8 +38,8 @@ export interface ControlFunctions {
 }
 
 /**
- * Subsequent calls to the debounced function `debounced.callback` return the result of the last func invocation.
- * Note, that if there are no previous invocations it's mean you will get undefined. You should check it in your code properly.
+ * Subsequent calls to the debounced function return the result of the last func invocation.
+ * Note, that if there are no previous invocations you will get undefined. You should check it in your code properly.
  */
 export interface DebouncedState<T extends (...args: any) => ReturnType<T>>
   extends ControlFunctions {

--- a/src/useThrottledCallback.ts
+++ b/src/useThrottledCallback.ts
@@ -49,8 +49,8 @@ import useDebouncedCallback, {
  * window.addEventListener('scroll', scrollHandler)
  *
  * // Invoke `renewToken` when the click event is fired, but not more than once every 5 minutes.
- * const { callback } = useThrottledCallback(renewToken, 300000, { 'trailing': false })
- * <button onClick={callback}>click</button>
+ * const throttled = useThrottledCallback(renewToken, 300000, { 'trailing': false })
+ * <button onClick={throttled}>click</button>
  *
  * // Cancel the trailing throttled invocation.
  * window.addEventListener('popstate', throttled.cancel);


### PR DESCRIPTION
The callback property in the `DebouncedState` interface has been removed [over 2 year ago](https://github.com/koenpunt/use-debounce/commit/045f960583ea37dc4a55df4ed7e542f1a1f0a05a).