### PR TITLE
Fix type declaration for flush()

### DIFF
--- a/src/useDebouncedCallback.ts
+++ b/src/useDebouncedCallback.ts
@@ -22,7 +22,7 @@ export interface Options extends CallOptions {
   debounceOnServer?: boolean;
 }
 
-export interface ControlFunctions {
+export interface ControlFunctions<ReturnT> {
   /**
    * Cancel pending function invocations
    */
@@ -30,7 +30,7 @@ export interface ControlFunctions {
   /**
    * Immediately invoke pending function invocations
    */
-  flush: () => void;
+  flush: () => ReturnT | undefined;
   /**
    * Returns `true` if there are any pending function invocations
    */
@@ -42,7 +42,7 @@ export interface ControlFunctions {
  * Note, that if there are no previous invocations you will get undefined. You should check it in your code properly.
  */
 export interface DebouncedState<T extends (...args: any) => ReturnType<T>>
-  extends ControlFunctions {
+  extends ControlFunctions<ReturnType<T>> {
   (...args: Parameters<T>): ReturnType<T> | undefined;
 }
 

--- a/test/useDebouncedCallback.test.tsx
+++ b/test/useDebouncedCallback.test.tsx
@@ -500,7 +500,7 @@ describe('useDebouncedCallback', () => {
 
       debounced();
       useEffect(() => {
-        return debounced.flush;
+        return () => { debounced.flush(); };
       }, []);
       return <span role="test">{text}</span>;
     }


### PR DESCRIPTION
The `flush()` function returns the result of the most recent function invocation, however, the type declaration did not reflect this correctly. This PR updates the Typescript declaration to match the actual return-type of the function.

Fixes #174 