### PR TITLE
Ensure compatibility with React 16.8.0 and above in peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "dist"
   ],
   "peerDependencies": {
-    "react": "*"
+    "react": ">=16.8.0"
   },
   "homepage": "https://github.com/xnimorz/use-debounce#readme",
   "devDependencies": {


### PR DESCRIPTION
## Summary
This pull request updates the `peerDependencies` for React to ensure compatibility with React version `16.8.0` and above. This change is necessary to leverage features introduced in React `16.8.0`, such as hooks, and to ensure that our package works correctly with these versions.

## Changes
Updated the `peerDependencies` in `package.json`:

## Impact
- **Compatibility**: Ensures that the package is compatible with React `16.8.0` and above.
- **Features**: Allows the use of React hooks and other features introduced in React `16.8.0`.
- **Dependency Management**: Prevents the package from being used with versions of React that do not support hooks, reducing potential issues and bugs.

## Testing
Verified that the package works correctly with React `16.8.0` and above.

Here is the repo of a React app running on `16.8.0` to manually inspect everything that is working as expected.

https://github.com/dianjuar/use-debounce-proof-of-concept/tree/main/react-apps

The app is [deployed on github pages](https://dianjuar.github.io/use-debounce-proof-of-concept/build-16-8-0/index.html)

## Additional Notes

Users of this package will need to ensure they are using React `16.8.0` or above to avoid compatibility issues.

This change does not affect the functionality of the package but ensures that it is used with compatible versions of React.

These changes might seem irrelevant, especially since React hooks have been around for six years, but there are still 16,928 weekly downloads of React `16.7.0`. These changes are required to effectively indicate to those users that they must have at least `16.8.0` to run your package.