### PR TITLE
Update outdated tsdoc for useDebouncedCallback

### DIFF
--- a/src/useDebouncedCallback.ts
+++ b/src/useDebouncedCallback.ts
@@ -110,7 +110,7 @@ export interface DebouncedState<T extends (...args: any) => ReturnType<T>>
  * window.addEventListener('popstate', debounced.cancel)
  *
  * // Check for pending invocations.
- * const status = debounced.pending() ? "Pending..." : "Ready"
+ * const status = debounced.isPending() ? "Pending..." : "Ready"
  */
 export default function useDebouncedCallback<
   T extends (...args: any) => ReturnType<T>,


### PR DESCRIPTION
Hi there! I'm pretty sure `.pending()` hasn't existed in a while, but is still shown in the TSDoc for `useDebouncedCallback`. Here's a fix!