### PR TITLE
Fix/cancel ispending UI update

### DIFF
--- a/src/useDebouncedCallback.ts
+++ b/src/useDebouncedCallback.ts
@@ -286,6 +286,7 @@ export default function useDebouncedCallback<
     };
 
     func.cancel = () => {
+      const hadTimer = !!timerId.current;
       if (timerId.current) {
         useRAF
           ? cancelAnimationFrame(timerId.current)
@@ -297,6 +298,11 @@ export default function useDebouncedCallback<
         lastThis.current =
         timerId.current =
           null;
+
+      // Notify React to re-render when cancel is called and there was an active timer
+      if (hadTimer && forceUpdate) {
+        forceUpdate({});
+      }
     };
 
     func.isPending = () => {

--- a/test/useDebounce.test.tsx
+++ b/test/useDebounce.test.tsx
@@ -538,4 +538,50 @@ describe('useDebounce', () => {
     // @ts-ignore
     expect(screen.getByRole('pending')).toHaveTextContent('false');
   });
+
+  it('Updates isPending UI when cancel is called', () => {
+    function Component({ text }) {
+      const [value, { cancel, isPending }] = useDebounce(text, 1000);
+      return (
+        <div>
+          <div role="value">{value}</div>
+          <div role="pending">{isPending().toString()}</div>
+          <button role="cancel" onClick={() => cancel()}>
+            Cancel
+          </button>
+        </div>
+      );
+    }
+
+    const tree = render(<Component text={'Hello'} />);
+
+    // Initially, not pending
+    // @ts-ignore
+    expect(screen.getByRole('value')).toHaveTextContent('Hello');
+    // @ts-ignore
+    expect(screen.getByRole('pending')).toHaveTextContent('false');
+
+    // Update text to trigger debounce
+    act(() => {
+      tree.rerender(<Component text={'World'} />);
+    });
+
+    // Should be pending now
+    // @ts-ignore
+    expect(screen.getByRole('value')).toHaveTextContent('Hello');
+    // @ts-ignore
+    expect(screen.getByRole('pending')).toHaveTextContent('true');
+
+    // Click cancel button
+    act(() => {
+      // @ts-ignore
+      screen.getByRole('cancel').click();
+    });
+
+    // After cancel, should not be pending and UI should update
+    // @ts-ignore
+    expect(screen.getByRole('value')).toHaveTextContent('Hello');
+    // @ts-ignore
+    expect(screen.getByRole('pending')).toHaveTextContent('false');
+  });
 });


### PR DESCRIPTION
## Summary
  This PR fixes an issue where the `isPending()` state doesn't trigger a UI update
  when `cancel()` is called on an active debounce timer.

  ## Problem
  When calling `cancel()` on an active debounce, the internal timer is cleared and
  `isPending()` returns `false`, but React doesn't re-render because only the ref
  value changes without triggering any state updates. This causes the UI to show
  stale pending status.

  ### Example of the issue:
  ```jsx
  function SearchComponent() {
    const [searchTerm, setSearchTerm] = useState('');
    const [debouncedValue, { cancel, isPending }] = useDebounce(searchTerm, 1000);

    return (
      <div>
        <input
          value={searchTerm}
          onChange={(e) => setSearchTerm(e.target.value)}
        />

        {/* This would show "Searching..." even after cancel() is called */}
        {isPending() && <span>Searching...</span>}

        <button onClick={() => cancel()}>
          Cancel Search
        </button>
      </div>
    );
  }
```
  Before this fix: When clicking "Cancel Search", the timer is cancelled but the
  "Searching..." text remains visible because the component doesn't re-render.

  After this fix: When clicking "Cancel Search", the component re-renders and
  "Searching..." disappears immediately.

  ## Solution

  - Added forceUpdate() call in the cancel() method when there's an active timer
  - Only triggers re-render when actually canceling an active timer (prevents
  unnecessary renders)

  ## Test

  Added test case "Updates isPending UI when cancel is called" that verifies:
  1. Initial state shows isPending() = false
  2. After triggering debounce, shows isPending() = true
  3. After calling cancel(), UI correctly updates to show isPending() = false

  ## Related

  - Continues the work from #196 which fixed similar issues for leading: true option
